### PR TITLE
Fixed ignition generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV IPXE_DIR '/data/ipxe'
 ENV BASE_URL http://localhost:8888
 ENV KERNEL_OPTS 'random.trust_cpu=on rd.luks.options=discard ignition.firstboot ignition.platform.id=metal console=tty0 console=ttyS0,115200n8 coreos.inst.persistent-kargs="console=tty0 console=ttyS1,115200n8"'
 
-RUN microdnf install xz genisoimage && microdnf clean all
+RUN microdnf install gzip genisoimage && microdnf clean all
 
 COPY iso_to_ipxe /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV IPXE_DIR '/data/ipxe'
 ENV BASE_URL http://localhost:8888
 ENV KERNEL_OPTS 'random.trust_cpu=on rd.luks.options=discard ignition.firstboot ignition.platform.id=metal console=tty0 console=ttyS0,115200n8 coreos.inst.persistent-kargs="console=tty0 console=ttyS1,115200n8"'
 
-RUN microdnf install gzip genisoimage && microdnf clean all
+RUN microdnf install xz gzip genisoimage && microdnf clean all
 
 COPY iso_to_ipxe /
 

--- a/iso_to_ipxe
+++ b/iso_to_ipxe
@@ -39,4 +39,19 @@ for img in $PXE_IMAGES; do
 done
  
 echo writing custom user ignition
-isoinfo -i $IMAGE -x '/IMAGES/IGNITION.IMG;1' | gunzip | sed "s/.*config.ign.*/{/" |sed "s/.*TRAILER.*/}/" >> $IPXE_DIR/config.ign
+
+# Check if ISO is gzipped or xzed
+IGNITION_IMG_TYPE=$(isoinfo -i $IMAGE -x '/IMAGES/IGNITION.IMG;1' | file - | awk '{print $2}')
+
+if [ $IGNITION_IMG_TYPE == "gzip" ]
+then
+  isoinfo -i $IMAGE -x '/IMAGES/IGNITION.IMG;1' | gunzip | sed "s/.*config.ign.*/{/" |sed "s/.*TRAILER.*/}/" > $IPXE_DIR/config.ign
+elif [ $IGNITION_IMG_TYPE == "XZ" ]
+then
+  echo '{' > $IPXE_DIR/config.ign
+  isoinfo -i $IMAGE -x '/IMAGES/IGNITION.IMG;1' | xz -dc - | sed '1d; $d' >> $IPXE_DIR/config.ign
+  echo '}' >> $IPXE_DIR/config.ign
+else
+  echo "Unknown ignition file type"
+  exit 1
+fi

--- a/iso_to_ipxe
+++ b/iso_to_ipxe
@@ -39,6 +39,4 @@ for img in $PXE_IMAGES; do
 done
  
 echo writing custom user ignition
-echo '{' > $IPXE_DIR/config.ign
-isoinfo -i $IMAGE -x '/IMAGES/IGNITION.IMG;1' | xz -dc - | sed '1d; $d' >> $IPXE_DIR/config.ign
-echo '}' >> $IPXE_DIR/config.ign
+isoinfo -i $IMAGE -x '/IMAGES/IGNITION.IMG;1' | gunzip | sed "s/.*config.ign.*/{/" |sed "s/.*TRAILER.*/}/" >> $IPXE_DIR/config.ign


### PR DESCRIPTION
New RHCOS images use a different format for the ignition.img file, when using xz it fails with `xz: (stdin): File format not recognized
`

Using gzip works now, updated files to use gzip instead of xz.