### PR TITLE
Added file utility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV IPXE_DIR '/data/ipxe'
 ENV BASE_URL http://localhost:8888
 ENV KERNEL_OPTS 'random.trust_cpu=on rd.luks.options=discard ignition.firstboot ignition.platform.id=metal console=tty0 console=ttyS0,115200n8 coreos.inst.persistent-kargs="console=tty0 console=ttyS1,115200n8"'
 
-RUN microdnf install xz gzip genisoimage && microdnf clean all
+RUN microdnf install xz gzip genisoimage file && microdnf clean all
 
 COPY iso_to_ipxe /
 


### PR DESCRIPTION
Fixes iso_to_pxe when running on podman:

./iso_to_ipxe: line 44: file: command not found

