### PR TITLE
uses cpio instead of sed substitutions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV IPXE_DIR '/data/ipxe'
 ENV BASE_URL http://localhost:8888
 ENV KERNEL_OPTS 'random.trust_cpu=on rd.luks.options=discard ignition.firstboot ignition.platform.id=metal console=tty1 console=ttyS1,115200n8 coreos.inst.persistent-kargs="console=tty1 console=ttyS1,115200n8"'
 
-RUN microdnf install xz gzip genisoimage file && microdnf clean all
+RUN microdnf install -y xz gzip genisoimage file cpio && microdnf clean all
 
 COPY iso_to_ipxe /
 

--- a/iso_to_ipxe
+++ b/iso_to_ipxe
@@ -45,7 +45,7 @@ IGNITION_IMG_TYPE=$(isoinfo -i $IMAGE -x '/IMAGES/IGNITION.IMG;1' | file - | awk
 
 if [ $IGNITION_IMG_TYPE == "gzip" ]
 then
-  isoinfo -i $IMAGE -x '/IMAGES/IGNITION.IMG;1' | gunzip | sed "s/.*config.ign.*/{/" |sed "s/.*TRAILER.*/}/" > $IPXE_DIR/config.ign
+  isoinfo -i $IMAGE -x '/IMAGES/IGNITION.IMG;1' | gunzip | cpio -i --to-stdout > $IPXE_DIR/config.ign
 elif [ $IGNITION_IMG_TYPE == "XZ" ]
 then
   echo '{' > $IPXE_DIR/config.ign


### PR DESCRIPTION
Using cpio to extract the ignition file from the archive should make it
more clear what the script is doing, and it might be more robust toward
any subtle file changes in the future.