### PR TITLE
uses bash explicitly to avoid compatibility problems

### DIFF
--- a/iso_to_ipxe
+++ b/iso_to_ipxe
@@ -1,4 +1,4 @@
-#! /bin/sh -e
+#! /bin/bash -e
 
 # USAGE: iso_to_pxe path/to/image.iso
 #


### PR DESCRIPTION
fixes #6

Fedora-derived distributions symlink /bin/sh to /bin/bash. Ubuntu
however links to /bin/dash, which is not bash-compatible. That resulted
in errors running this script on Ubuntu systems. This change explicitly
uses bash, enabling the script to run without error.