### PR TITLE
workaround quay build issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:latest
+FROM registry.fedoraproject.org/fedora-minimal:34
 
 ENV IMAGE '/data/image.iso'
 ENV IPXE_DIR '/data/ipxe'


### PR DESCRIPTION
Quay is unable to build on Fedora 35 from some reason (details at https://issues.redhat.com/browse/PROJQUAY-3675)

downgrading Fedora so that we have latest builds published.